### PR TITLE
Fix chrome options for ChromeDriver 75

### DIFF
--- a/lib/congress_forms.rb
+++ b/lib/congress_forms.rb
@@ -37,7 +37,7 @@ Capybara.register_driver :remote do
       nativeEvents: false,
       rotatable: false,
       takesScreenshot: true,
-      chromeOptions: {
+      chrome_options: {
         args: %w(headless new-window no-sandbox disable-dev-shm-usage disable-gpu window-size=1200,1400)
       }
     }
@@ -46,9 +46,9 @@ end
 
 Capybara.register_driver :headless_chrome do
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
+    chrome_options: {
       args: %w(new-window no-sandbox disable-dev-shm-usage disable-gpu window-size=1200,1400).tap do |o|
-        o.push("--headless") unless ENV["HEADLESS"] == "0"
+        o.push("headless") unless ENV["HEADLESS"] == "0"
       end
     }
   )


### PR DESCRIPTION
https://github.com/flavorjones/chromedriver-helper was giving us an old version, 2.35. https://github.com/titusfortner/webdrivers is giving us version 75 (not as bad as it sounds, Chrome starting giving the drivers names that match the browser version at version 70).

I'm not sure where these options get parsed, but maybe the driver is being stricter now. In any case, this stops Selenium from trying to launch a headful browser on my sandbox.